### PR TITLE
feat: implement UI manager with overlays

### DIFF
--- a/src/presentation/UIManager.ts
+++ b/src/presentation/UIManager.ts
@@ -34,39 +34,158 @@ export interface IUIManager {
 }
 
 export class UIManager implements IUIManager {
-  private scene: any; // Will be properly typed with Phaser types
+  private scene: any; // Phaser.Scene
+
+  // Cached UI elements so they can be updated or destroyed safely
+  private scoreText?: any;
+  private timerText?: any;
+  private orbText?: any;
+  private objectiveTexts: any[] = [];
+
+  // Overlay elements
+  private pauseOverlay?: any;
+  private pauseText?: any;
+  private gameCompleteOverlay?: any;
+  private gameCompleteText?: any;
 
   constructor(scene: any) {
     this.scene = scene;
   }
 
+  /**
+   * Update all on-screen UI elements to reflect the current game state.
+   * Creates elements on first use and reuses them on subsequent calls.
+   */
   updateUI(gameState: GameState): void {
-    // Implementation will be added in later tasks
-    throw new Error('Not implemented yet');
+    // Score and timer
+    this.updateScore(gameState.score);
+
+    const elapsed = Math.floor(
+      (gameState.currentTime - gameState.startTime - gameState.pausedTime) / 1000
+    );
+    this.updateTimer(elapsed);
+
+    // Orb status
+    const collected = gameState.orbs.filter((o) => o.collected).length;
+    const total = gameState.orbs.length;
+    const orbStatus = `Orbs: ${collected}/${total}`;
+    if (!this.orbText) {
+      this.orbText = this.scene.add?.text(10, 50, orbStatus);
+    } else {
+      this.orbText.setText?.(orbStatus);
+    }
+
+    // Objective indicators
+    const baseX = 10;
+    const baseY = 70;
+    const spacing = 20;
+
+    // Remove extra objective texts
+    while (this.objectiveTexts.length > gameState.objectives.length) {
+      const textObj = this.objectiveTexts.pop();
+      textObj?.destroy?.();
+    }
+
+    gameState.objectives.forEach((obj, index) => {
+      const description = `${obj.description}: ${obj.current}/${obj.target}`;
+      let textObj = this.objectiveTexts[index];
+      if (!textObj) {
+        textObj = this.scene.add?.text(baseX, baseY + index * spacing, description);
+        this.objectiveTexts[index] = textObj;
+      } else {
+        textObj.setText?.(description);
+      }
+    });
   }
 
+  /**
+   * Display a simple game completion overlay.
+   */
   showGameComplete(score: number, time: number, stars: number): void {
-    // Implementation will be added in later tasks
-    throw new Error('Not implemented yet');
+    // Clean up any existing overlay first
+    this.gameCompleteOverlay?.destroy?.();
+    this.gameCompleteText?.destroy?.();
+
+    const width = this.scene.cameras?.main?.width ?? 800;
+    const height = this.scene.cameras?.main?.height ?? 600;
+
+    if (this.scene.add?.rectangle) {
+      this.gameCompleteOverlay = this.scene.add.rectangle(
+        width / 2,
+        height / 2,
+        width,
+        height,
+        0x000000,
+        0.5
+      );
+    } else {
+      const g = this.scene.add?.graphics();
+      g?.fillStyle?.(0x000000, 0.5);
+      g?.fillRect?.(0, 0, width, height);
+      this.gameCompleteOverlay = g;
+    }
+
+    const text = `Level Complete!\nScore: ${score}\nTime: ${time}\nStars: ${stars}`;
+    this.gameCompleteText = this.scene.add?.text(width / 2, height / 2, text, {
+      align: 'center',
+    });
+    this.gameCompleteText?.setOrigin?.(0.5);
   }
 
+  /** Show pause overlay. Subsequent calls have no effect. */
   showPauseMenu(): void {
-    // Implementation will be added in later tasks
-    throw new Error('Not implemented yet');
+    if (this.pauseOverlay || this.pauseText) return;
+
+    const width = this.scene.cameras?.main?.width ?? 800;
+    const height = this.scene.cameras?.main?.height ?? 600;
+
+    if (this.scene.add?.rectangle) {
+      this.pauseOverlay = this.scene.add.rectangle(
+        width / 2,
+        height / 2,
+        width,
+        height,
+        0x000000,
+        0.5
+      );
+    } else {
+      const g = this.scene.add?.graphics();
+      g?.fillStyle?.(0x000000, 0.5);
+      g?.fillRect?.(0, 0, width, height);
+      this.pauseOverlay = g;
+    }
+
+    this.pauseText = this.scene.add?.text(width / 2, height / 2, 'Paused', {
+      align: 'center',
+    });
+    this.pauseText?.setOrigin?.(0.5);
   }
 
+  /** Hide pause overlay if it is currently displayed. */
   hidePauseMenu(): void {
-    // Implementation will be added in later tasks
-    throw new Error('Not implemented yet');
+    this.pauseOverlay?.destroy?.();
+    this.pauseText?.destroy?.();
+    this.pauseOverlay = undefined;
+    this.pauseText = undefined;
   }
 
+  /** Update only the score text element. */
   updateScore(score: number): void {
-    // Implementation will be added in later tasks
-    throw new Error('Not implemented yet');
+    const text = `Score: ${score}`;
+    if (!this.scoreText) {
+      this.scoreText = this.scene.add?.text(10, 10, text);
+    } else {
+      this.scoreText.setText?.(text);
+    }
   }
 
+  /** Update only the timer text element. */
   updateTimer(time: number): void {
-    // Implementation will be added in later tasks
-    throw new Error('Not implemented yet');
+    const text = `Time: ${time}`;
+    if (!this.timerText) {
+      this.timerText = this.scene.add?.text(10, 30, text);
+    } else {
+      this.timerText.setText?.(text);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add UIManager methods to update score, timer, orb and objectives
- render pause and completion overlays using Phaser text and graphics
- keep UI elements reusable and cleaned up on repeated calls

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6175571148324861d13cffc70b98e