### PR TITLE
feat: implement resume support and state test

### DIFF
--- a/src/services/GameService.test.ts
+++ b/src/services/GameService.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { GameService } from './GameService';
+import { IGameCore, Direction } from '../core/GameCore';
+import { LevelDefinition } from '../core/types/Level';
+import { GameState, Player, PlayerStats } from '../core/types/GameState';
+
+class MockGameCore implements IGameCore {
+  public gameState: GameState;
+  public startCalls = 0;
+  public resumeCalls = 0;
+  public pauseCalls = 0;
+
+  constructor() {
+    const playerStats: PlayerStats = {
+      totalMoves: 0,
+      orbsCollected: 0,
+      timeElapsed: 0,
+      powerupsUsed: 0,
+      hintsUsed: 0,
+    };
+
+    const player: Player = {
+      position: { x: 0, y: 0 },
+      inventory: [],
+      stats: playerStats,
+      activePowerups: [],
+    };
+
+    this.gameState = {
+      levelId: 'test',
+      levelConfig: {} as LevelDefinition,
+      status: 'initializing',
+      startTime: 0,
+      currentTime: 0,
+      pausedTime: 0,
+      player,
+      maze: [],
+      orbs: [],
+      powerups: [],
+      objectives: [],
+      score: 0,
+      moves: 0,
+      hintsUsed: 0,
+      version: 1,
+    };
+  }
+
+  initializeLevel(levelDefinition: LevelDefinition): void {
+    this.gameState.levelConfig = levelDefinition;
+    this.gameState.levelId = levelDefinition.id;
+  }
+
+  startGame(): void {
+    this.startCalls++;
+    this.gameState.status = 'playing';
+  }
+
+  pauseGame(): void {
+    this.pauseCalls++;
+    this.gameState.status = 'paused';
+  }
+
+  resumeGame(): void {
+    this.resumeCalls++;
+    this.gameState.status = 'playing';
+  }
+
+  resetGame(): void {
+    this.gameState.status = 'initializing';
+  }
+
+  movePlayer(direction: Direction) {
+    return { success: true } as any;
+  }
+
+  collectOrb(orbId: string) {
+    return { success: true } as any;
+  }
+
+  getGameState(): Readonly<GameState> {
+    return this.gameState;
+  }
+
+  isGameComplete(): boolean {
+    return false;
+  }
+
+  getScore(): number {
+    return 0;
+  }
+
+  getCurrentTime(): number {
+    return 0;
+  }
+
+  on(): void {}
+  off(): void {}
+  once(): void {}
+}
+
+describe('GameService', () => {
+  it('maintains state when paused and resumed', () => {
+    const core = new MockGameCore();
+    const service = new GameService(core, {} as any);
+
+    service.startGame();
+    core.gameState.moves = 5;
+
+    service.pauseGame();
+    expect(core.gameState.status).toBe('paused');
+
+    service.resumeGame();
+    expect(core.gameState.status).toBe('playing');
+    expect(core.gameState.moves).toBe(5);
+    expect(core.startCalls).toBe(1);
+    expect(core.resumeCalls).toBe(1);
+  });
+});

--- a/src/services/GameService.ts
+++ b/src/services/GameService.ts
@@ -21,7 +21,7 @@ export interface IGameService {
   pauseGame(): void;
 
   /**
-   * Resumes the current game
+   * Resumes a paused game, transitioning back to playing without reinitializing the level
    */
   resumeGame(): void;
 
@@ -70,8 +70,11 @@ export class GameService implements IGameService {
     this.gameCore.pauseGame();
   }
 
+  /**
+   * Resumes a paused game without reinitializing the level.
+   */
   resumeGame(): void {
-    this.gameCore.startGame(); // Resume is same as start for now
+    this.gameCore.resumeGame();
   }
 
   resetGame(): void {


### PR DESCRIPTION
## Summary
- call `resumeGame` on core and document pause-to-play transition
- add unit test ensuring pause/resume keeps game state

## Testing
- `npm run test:run` (fails: PerformanceValidation.test etc.)
- `npx vitest run src/services/GameService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a61b66ecdc8324bf7c0c30727ed123